### PR TITLE
Add riscv64 as an emulated target.

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,8 +8,20 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_:
-        CONFIG: linux_64_
+      linux_64_target_emulated_platformaarch64:
+        CONFIG: linux_64_target_emulated_platformaarch64
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_target_emulated_platformppc64le:
+        CONFIG: linux_64_target_emulated_platformppc64le
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_target_emulated_platformriscv64:
+        CONFIG: linux_64_target_emulated_platformriscv64
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_target_emulated_platforms390x:
+        CONFIG: linux_64_target_emulated_platforms390x
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -12,10 +12,6 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-emulated_c_stdlib:
-- sysroot
-emulated_c_stdlib_version:
-- '2.28'
 emulated_targets:
 - aarch64 ppc64le s390x riscv64
 glib:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -17,16 +17,18 @@ emulated_c_stdlib:
 emulated_c_stdlib_version:
 - '2.28'
 emulated_targets:
-- aarch64 ppc64le s390x
+- aarch64 ppc64le s390x riscv64
 glib:
 - '2'
 target_emulated_gcc:
 - aarch64-conda-linux-gnu-gcc
 - powerpc64le-conda-linux-gnu-gcc
+- riscv64-conda-linux-gnu-gcc
 - s390x-conda-linux-gnu-gcc
 target_emulated_platform:
 - aarch64
 - ppc64le
+- riscv64
 - s390x
 target_platform:
 - linux-64

--- a/.ci_support/linux_64_target_emulated_platformaarch64.yaml
+++ b/.ci_support/linux_64_target_emulated_platformaarch64.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
+- '2.28'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_64_target_emulated_platformaarch64.yaml
+++ b/.ci_support/linux_64_target_emulated_platformaarch64.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.28'
+- '2.17'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -18,14 +18,8 @@ glib:
 - '2'
 target_emulated_gcc:
 - aarch64-conda-linux-gnu-gcc
-- powerpc64le-conda-linux-gnu-gcc
-- riscv64-conda-linux-gnu-gcc
-- s390x-conda-linux-gnu-gcc
 target_emulated_platform:
 - aarch64
-- ppc64le
-- riscv64
-- s390x
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_target_emulated_platformppc64le.yaml
+++ b/.ci_support/linux_64_target_emulated_platformppc64le.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
+- '2.28'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_64_target_emulated_platformppc64le.yaml
+++ b/.ci_support/linux_64_target_emulated_platformppc64le.yaml
@@ -1,0 +1,29 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+emulated_targets:
+- aarch64 ppc64le s390x riscv64
+glib:
+- '2'
+target_emulated_gcc:
+- powerpc64le-conda-linux-gnu-gcc
+target_emulated_platform:
+- ppc64le
+target_platform:
+- linux-64
+zip_keys:
+- - target_emulated_platform
+  - target_emulated_gcc
+zlib:
+- '1'

--- a/.ci_support/linux_64_target_emulated_platformriscv64.yaml
+++ b/.ci_support/linux_64_target_emulated_platformriscv64.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
+- '2.28'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_64_target_emulated_platformriscv64.yaml
+++ b/.ci_support/linux_64_target_emulated_platformriscv64.yaml
@@ -1,0 +1,29 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+emulated_targets:
+- aarch64 ppc64le s390x riscv64
+glib:
+- '2'
+target_emulated_gcc:
+- riscv64-conda-linux-gnu-gcc
+target_emulated_platform:
+- riscv64
+target_platform:
+- linux-64
+zip_keys:
+- - target_emulated_platform
+  - target_emulated_gcc
+zlib:
+- '1'

--- a/.ci_support/linux_64_target_emulated_platforms390x.yaml
+++ b/.ci_support/linux_64_target_emulated_platforms390x.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
+- '2.28'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_64_target_emulated_platforms390x.yaml
+++ b/.ci_support/linux_64_target_emulated_platforms390x.yaml
@@ -1,0 +1,29 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+emulated_targets:
+- aarch64 ppc64le s390x riscv64
+glib:
+- '2'
+target_emulated_gcc:
+- s390x-conda-linux-gnu-gcc
+target_emulated_platform:
+- s390x
+target_platform:
+- linux-64
+zip_keys:
+- - target_emulated_platform
+  - target_emulated_gcc
+zlib:
+- '1'

--- a/README.md
+++ b/README.md
@@ -32,10 +32,31 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64</td>
+              <td>linux_64_target_emulated_platformaarch64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=25089&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qemu-execve-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qemu-execve-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_target_emulated_platformaarch64" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_target_emulated_platformppc64le</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=25089&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qemu-execve-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_target_emulated_platformppc64le" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_target_emulated_platformriscv64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=25089&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qemu-execve-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_target_emulated_platformriscv64" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_target_emulated_platforms390x</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=25089&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qemu-execve-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_target_emulated_platforms390x" alt="variant">
                 </a>
               </td>
             </tr>

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Current release info
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-qemu--execve--aarch64-green.svg)](https://anaconda.org/conda-forge/qemu-execve-aarch64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/qemu-execve-aarch64.svg)](https://anaconda.org/conda-forge/qemu-execve-aarch64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/qemu-execve-aarch64.svg)](https://anaconda.org/conda-forge/qemu-execve-aarch64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/qemu-execve-aarch64.svg)](https://anaconda.org/conda-forge/qemu-execve-aarch64) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-qemu--execve--ppc64le-green.svg)](https://anaconda.org/conda-forge/qemu-execve-ppc64le) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/qemu-execve-ppc64le.svg)](https://anaconda.org/conda-forge/qemu-execve-ppc64le) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/qemu-execve-ppc64le.svg)](https://anaconda.org/conda-forge/qemu-execve-ppc64le) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/qemu-execve-ppc64le.svg)](https://anaconda.org/conda-forge/qemu-execve-ppc64le) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-qemu--execve--riscv64-green.svg)](https://anaconda.org/conda-forge/qemu-execve-riscv64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/qemu-execve-riscv64.svg)](https://anaconda.org/conda-forge/qemu-execve-riscv64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/qemu-execve-riscv64.svg)](https://anaconda.org/conda-forge/qemu-execve-riscv64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/qemu-execve-riscv64.svg)](https://anaconda.org/conda-forge/qemu-execve-riscv64) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-qemu--execve--s390x-green.svg)](https://anaconda.org/conda-forge/qemu-execve-s390x) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/qemu-execve-s390x.svg)](https://anaconda.org/conda-forge/qemu-execve-s390x) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/qemu-execve-s390x.svg)](https://anaconda.org/conda-forge/qemu-execve-s390x) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/qemu-execve-s390x.svg)](https://anaconda.org/conda-forge/qemu-execve-s390x) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-qemu--shared--resources-green.svg)](https://anaconda.org/conda-forge/qemu-shared-resources) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/qemu-shared-resources.svg)](https://anaconda.org/conda-forge/qemu-shared-resources) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/qemu-shared-resources.svg)](https://anaconda.org/conda-forge/qemu-shared-resources) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/qemu-shared-resources.svg)](https://anaconda.org/conda-forge/qemu-shared-resources) |
 
@@ -66,16 +67,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `qemu-execve-aarch64, qemu-execve-ppc64le, qemu-execve-s390x, qemu-shared-resources` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `qemu-execve-aarch64, qemu-execve-ppc64le, qemu-execve-riscv64, qemu-execve-s390x, qemu-shared-resources` can be installed with `conda`:
 
 ```
-conda install qemu-execve-aarch64 qemu-execve-ppc64le qemu-execve-s390x qemu-shared-resources
+conda install qemu-execve-aarch64 qemu-execve-ppc64le qemu-execve-riscv64 qemu-execve-s390x qemu-shared-resources
 ```
 
 or with `mamba`:
 
 ```
-mamba install qemu-execve-aarch64 qemu-execve-ppc64le qemu-execve-s390x qemu-shared-resources
+mamba install qemu-execve-aarch64 qemu-execve-ppc64le qemu-execve-riscv64 qemu-execve-s390x qemu-shared-resources
 ```
 
 It is possible to list all of the versions of `qemu-execve-aarch64` available on your platform with `conda`:

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -6,3 +6,6 @@ conda_build:
 conda_forge_output_validation: true
 bot:
   automerge: true
+linter:
+  skip:
+    - lint_stdlib

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,6 @@
 c_stdlib_version:
   - "2.28"  # [linux and not riscv64]
-  - "2.39"  # [linux and riscv64]
+  - "2.34"  # [linux and riscv64]
 emulated_targets: "aarch64 ppc64le s390x riscv64"
 target_emulated_gcc:
   - aarch64-conda-linux-gnu-gcc

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,6 @@
 c_stdlib_version:
   - "2.28"  # [linux and not riscv64]
-  - "2.34"  # [linux and riscv64]
+  - "2.39"  # [linux and riscv64]
 emulated_targets: "aarch64 ppc64le s390x riscv64"
 target_emulated_gcc:
   - aarch64-conda-linux-gnu-gcc

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,3 @@
-c_stdlib_version:
-  - "2.28"  # [linux and not riscv64]
-  - "2.39"  # [linux and riscv64]
 emulated_targets: "aarch64 ppc64le s390x riscv64"
 target_emulated_gcc:
   - aarch64-conda-linux-gnu-gcc

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,7 +1,10 @@
-c_stdlib_version:
-  - "2.28"  # [linux and not riscv64]
-  - "2.39"  # [linux and riscv64]
+# We need a higher baseline (QEMU requires GLIBC >= 2.28)
+# Note: The emulated target c_stdlib_version is set in meta.yaml (until riscv64 is a selector)
+c_stdlib_version:  # [linux]
+  - "2.28"         # [linux]
+
 emulated_targets: "aarch64 ppc64le s390x riscv64"
+
 target_emulated_gcc:
   - aarch64-conda-linux-gnu-gcc
   - powerpc64le-conda-linux-gnu-gcc

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,6 @@
+c_stdlib_version:
+  - "2.28"  # [linux and not riscv64]
+  - "2.39"  # [linux and riscv64]
 emulated_targets: "aarch64 ppc64le s390x riscv64"
 target_emulated_gcc:
   - aarch64-conda-linux-gnu-gcc

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,6 @@
 c_stdlib_version:
   - "2.28"  # [linux]
-emulated_targets: "aarch64 ppc64le s390x"
+emulated_targets: "aarch64 ppc64le s390x riscv64"
 # This is to avoid warning about not using {{stdlib('c')}} in the recipe
 emulated_c_stdlib:
   - sysroot
@@ -10,10 +10,12 @@ target_emulated_gcc:
   - aarch64-conda-linux-gnu-gcc
   - powerpc64le-conda-linux-gnu-gcc
   - s390x-conda-linux-gnu-gcc
+  - riscv64-conda-linux-gnu-gcc
 target_emulated_platform:
   - aarch64
   - ppc64le
   - s390x
+  - riscv64
 zip_keys:
   - - target_emulated_platform
     - target_emulated_gcc

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,11 +1,7 @@
 c_stdlib_version:
-  - "2.28"  # [linux]
+  - "2.28"  # [linux and not riscv64]
+  - "2.39"  # [linux and riscv64]
 emulated_targets: "aarch64 ppc64le s390x riscv64"
-# This is to avoid warning about not using {{stdlib('c')}} in the recipe
-emulated_c_stdlib:
-  - sysroot
-emulated_c_stdlib_version:
-  - "2.28"
 target_emulated_gcc:
   - aarch64-conda-linux-gnu-gcc
   - powerpc64le-conda-linux-gnu-gcc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -136,11 +136,11 @@ outputs:
         # waiting for https://github.com/conda-forge/ctng-compilers-feedstock/pull/205 to be merged
         {% if target_emulated_platform != "riscv64" %}
         # Test the normal execution of a cross-compiled binary
-        - {{ target_emulated_gcc }} -Wl,-rpath,${QEMU_LD_PREFIX}/lib -Wl,-rpath,${QEMU_LD_PREFIX}/lib64 -L$QEMU_LD_PREFIX/lib64:$QEMU_LD_PREFIX/lib -Wl,--dynamic-linker=$QEMU_LD_PREFIX/lib/ld-{{ c_stdlib_version }}.so -o hello_from tests/hello_from.c
+        - {{ target_emulated_gcc }} -Wl,-rpath,${QEMU_LD_PREFIX}/lib -Wl,-rpath,${QEMU_LD_PREFIX}/lib64 -L$QEMU_LD_PREFIX/lib64:$QEMU_LD_PREFIX/lib -o hello_from tests/hello_from.c
         - qemu-execve-{{ target_emulated_platform }} ./hello_from {{ target_emulated_platform }} > hello.txt
         - grep "Hello, I'm executing {{ target_emulated_platform }} instructions!" hello.txt
         # Test the typical execve() execution of a non-cross-compiled binary (x86_64)
-        - {{ target_emulated_gcc }} -Wl,-rpath,${QEMU_LD_PREFIX}/lib -Wl,-rpath,${QEMU_LD_PREFIX}/lib64 -L$QEMU_LD_PREFIX/lib64:$QEMU_LD_PREFIX/lib -Wl,--dynamic-linker=$QEMU_LD_PREFIX/lib/ld-{{ c_stdlib_version }}.so -o execve_call tests/execve_call.c
+        - {{ target_emulated_gcc }} -Wl,-rpath,${QEMU_LD_PREFIX}/lib -Wl,-rpath,${QEMU_LD_PREFIX}/lib64 -L$QEMU_LD_PREFIX/lib64:$QEMU_LD_PREFIX/lib -o execve_call tests/execve_call.c
         - qemu-execve-{{ target_emulated_platform }} ./execve_call "/bin/ls" > ls_x86_64.txt 2>&1 || true
         - grep "hello_from" ls_x86_64.txt
         # Test redirected execve() execution of a non-cross-compiled binary (x86_64) - Must fail with 'Invalid ELF image'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,11 +43,8 @@ requirements:
   host:
     - libcapstone
     - glib
-    # - libseccomp
     - libslirp
     - meson >=1.1.0
-    # - sphinx >=3.4.3
-    # - sphinx-rtd-theme >=0.5
     - zlib
 
 outputs:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -123,7 +123,7 @@ outputs:
         - test -f ${PREFIX}/bin/qemu-execve-{{ target_emulated_platform }}
         - test -f ${PREFIX}/etc/conda/activate.d/qemu-execve-{{ target_emulated_platform }}-activate.sh
         - test -f ${PREFIX}/etc/conda/deactivate.d/qemu-execve-{{ target_emulated_platform }}-deactivate.sh
-        - test -f ${QEMU_LD_PREFIX}/lib/ld-{{ emulated_c_stdlib_version }}.so # [target_emulated_platform != "riscv64"]
+        - test -f ${QEMU_LD_PREFIX}/lib/ld-{{ emulated_c_stdlib_version }}.so  # [target_emulated_platform != "riscv64"]
         - qemu-execve-{{ target_emulated_platform }} -h
         {% if target_emulated_platform != "riscv64" %}
         # Test the normal execution of a cross-compiled binary
@@ -142,8 +142,8 @@ outputs:
         - grep "EXECVE" execve_call.txt || exit 1
         {% endif %}
       requires:
-        - gcc_impl_linux-{{ target_emulated_platform }} # [target_emulated_platform != "riscv64"]
-        - sysroot_linux-{{ target_emulated_platform }} {{ emulated_c_stdlib_version }}.* # [target_emulated_platform != "riscv64"]
+        - gcc_impl_linux-{{ target_emulated_platform }}  # [target_emulated_platform != "riscv64"]
+        - sysroot_linux-{{ target_emulated_platform }} {{ emulated_c_stdlib_version }}.*  # [target_emulated_platform != "riscv64"]
       files:
         - tests/hello_from.c
         - tests/execve_call.c

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,9 @@
 # override c_stdlib_version for riscv because we cannot do it in CBC yet, see
 # https://github.com/conda/conda-build/issues/5884
 {% if target_emulated_platform == "riscv64" %}
-{% set c_stdlib_version = "2.39" %}
+{% set emulated_c_stdlib_version = "2.39" %}
+{% else %}
+{% set emulated_c_stdlib_version = "2.28" %}
 {% endif %}
 
 package:
@@ -47,6 +49,8 @@ source:
 build:
   skip: true  # [not (linux and x86_64)]
   number: 1
+  ignore_run_exports_from:
+    - {{ stdlib('c') }}
   script:
     - ${RECIPE_DIR}/helpers/build-install.sh
   script_env:
@@ -122,7 +126,7 @@ outputs:
         - zlib
         {% endif %}
       run:
-        - {{ c_stdlib }}_linux-{{ target_emulated_platform }} >={{ c_stdlib_version }}
+        - sysroot_linux-{{ target_emulated_platform }} >={{ emulated_c_stdlib_version }}
     test:
       commands:
         - test -f ${PREFIX}/bin/qemu-execve-{{ target_emulated_platform }}
@@ -152,7 +156,6 @@ outputs:
       requires:
         # waiting for https://github.com/conda-forge/ctng-compilers-feedstock/pull/205 to be merged
         - gcc_impl_linux-{{ target_emulated_platform }}  # [target_emulated_platform != "riscv64"]
-        - sysroot_linux-{{ target_emulated_platform }} {{ c_stdlib_version }}.*  
       files:
         - tests/hello_from.c
         - tests/execve_call.c

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -123,8 +123,9 @@ outputs:
         - test -f ${PREFIX}/bin/qemu-execve-{{ target_emulated_platform }}
         - test -f ${PREFIX}/etc/conda/activate.d/qemu-execve-{{ target_emulated_platform }}-activate.sh
         - test -f ${PREFIX}/etc/conda/deactivate.d/qemu-execve-{{ target_emulated_platform }}-deactivate.sh
-        - test -f ${QEMU_LD_PREFIX}/lib/ld-{{ emulated_c_stdlib_version }}.so
+        - test -f ${QEMU_LD_PREFIX}/lib/ld-{{ emulated_c_stdlib_version }}.so # [target_emulated_platform != "riscv64"]
         - qemu-execve-{{ target_emulated_platform }} -h
+        {% if target_emulated_platform != "riscv64" %}
         # Test the normal execution of a cross-compiled binary
         - {{ target_emulated_gcc }} -Wl,-rpath,${QEMU_LD_PREFIX}/lib -Wl,-rpath,${QEMU_LD_PREFIX}/lib64 -L$QEMU_LD_PREFIX/lib64:$QEMU_LD_PREFIX/lib -Wl,--dynamic-linker=$QEMU_LD_PREFIX/lib/ld-{{ emulated_c_stdlib_version }}.so -o hello_from tests/hello_from.c
         - qemu-execve-{{ target_emulated_platform }} ./hello_from {{ target_emulated_platform }} > hello.txt
@@ -139,9 +140,10 @@ outputs:
         # Test redirected execve() execution of a cross-compiled binary - Redirected to qemu which executes the binary
         - QEMU_EXECVE=${PREFIX}/bin/qemu-execve-{{ target_emulated_platform }} qemu-execve-{{ target_emulated_platform }} ./execve_call "./hello_from" "EXECVE" > execve_call.txt 2>&1 || true
         - grep "EXECVE" execve_call.txt || exit 1
+        {% endif %}
       requires:
-        - gcc_impl_linux-{{ target_emulated_platform }}
-        - sysroot_linux-{{ target_emulated_platform }} {{ emulated_c_stdlib_version }}.*
+        - gcc_impl_linux-{{ target_emulated_platform }} # [target_emulated_platform != "riscv64"]
+        - sysroot_linux-{{ target_emulated_platform }} {{ emulated_c_stdlib_version }}.* # [target_emulated_platform != "riscv64"]
       files:
         - tests/hello_from.c
         - tests/execve_call.c

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,36 +1,6 @@
 {% set name = "qemu-execve" %}
 {% set version = "10.2.1" %}
 
-{% set qemu_bins = [
-  "trace-events-all",
-  "bios.bin", "bios-256k.bin", "bios-microvm.bin", "qboot.rom", "vgabios.bin", "vgabios-cirrus.bin",
-  "vgabios-stdvga.bin", "vgabios-vmware.bin", "vgabios-qxl.bin", "vgabios-virtio.bin", "vgabios-ramfb.bin",
-  "vgabios-bochs-display.bin", "vgabios-ati.bin", "openbios-sparc32", "openbios-sparc64", "openbios-ppc",
-  "QEMU,tcx.bin", "QEMU,cgthree.bin", "pxe-e1000.rom", "pxe-eepro100.rom", "pxe-ne2k_pci.rom", "pxe-pcnet.rom",
-  "pxe-rtl8139.rom", "pxe-virtio.rom", "efi-e1000.rom", "efi-eepro100.rom", "efi-ne2k_pci.rom", "efi-pcnet.rom",
-  "efi-rtl8139.rom", "efi-virtio.rom", "efi-e1000e.rom", "efi-vmxnet3.rom", "qemu-nsis.bmp", "multiboot.bin",
-  "multiboot_dma.bin", "linuxboot.bin", "linuxboot_dma.bin", "kvmvapic.bin", "pvh.bin", "s390-ccw.img",
-  "slof.bin",
-  "skiboot.lid", "palcode-clipper", "u-boot.e500",
-  "qemu_vga.ndrv", "edk2-licenses.txt", "hppa-firmware.img", "hppa-firmware64.img",
-  "opensbi-riscv32-generic-fw_dynamic.bin", "opensbi-riscv64-generic-fw_dynamic.bin", "npcm7xx_bootrom.bin",
-  "vof.bin", "vof-nvram.bin",
-  ]
-%}
-{% set qemu_keymaps = [
-  "ar", "bepo", "cz", "da", "de", "de-ch", "en-gb", "en-us", "es", "et", "fi", "fo", "fr", "fr-be", "fr-ca",
-  "fr-ch", "hr", "hu", "is", "it", "ja", "lt", "lv", "mk", "nl", "no", "pl", "pt", "pt-br", "ru", "th", "tr"
-  ]
-%}
-
-# override c_stdlib_version for riscv because we cannot do it in CBC yet, see
-# https://github.com/conda/conda-build/issues/5884
-{% if target_emulated_platform == "riscv64" %}
-  {% set emulated_c_stdlib_version = "2.39" %}
-{% else %}
-  {% set emulated_c_stdlib_version = "2.28" %}
-{% endif %}
-
 package:
   name: qemu-execve-split
   version: {{ version }}
@@ -76,11 +46,9 @@ requirements:
     # - libseccomp
     - libslirp
     - meson >=1.1.0
-    - sphinx >=3.4.3
-    - sphinx-rtd-theme >=0.5
-    {% if target_emulated_platform == "aarch64" %}
+    # - sphinx >=3.4.3
+    # - sphinx-rtd-theme >=0.5
     - zlib
-    {% endif %}
 
 outputs:
   - name: qemu-execve-{{ target_emulated_platform }}
@@ -112,6 +80,7 @@ outputs:
 
         # waiting for https://github.com/conda-forge/ctng-compilers-feedstock/pull/205 to be merged
         {% if target_emulated_platform != "riscv64" %}
+          {% set emulated_c_stdlib_version = "2.28" %}
         # Test the normal execution of a cross-compiled binary
         - export QEMU_CPU=power9  # [ppc64le]
         - {{ target_emulated_gcc }} -Wl,-rpath,${QEMU_LD_PREFIX}/lib -Wl,-rpath,${QEMU_LD_PREFIX}/lib64 -L$QEMU_LD_PREFIX/lib64:$QEMU_LD_PREFIX/lib -Wl,--dynamic-linker=$QEMU_LD_PREFIX/lib/ld-{{ emulated_c_stdlib_version }}.so -o hello_from tests/hello_from.c
@@ -127,12 +96,22 @@ outputs:
         # Test redirected execve() execution of a cross-compiled binary - Redirected to qemu which executes the binary
         - QEMU_EXECVE=${PREFIX}/bin/qemu-execve-{{ target_emulated_platform }} qemu-execve-{{ target_emulated_platform }} ./execve_call "./hello_from" "EXECVE" > execve_call.txt 2>&1 || true
         - grep "EXECVE" execve_call.txt || exit 1
+        {% else %}
+          {% set emulated_c_stdlib_version = "2.39" %}
         {% endif %}
+
       requires:
+
         # waiting for https://github.com/conda-forge/ctng-compilers-feedstock/pull/205 to be merged
-        - gcc_impl_linux-{{ target_emulated_platform }}  # [target_emulated_platform != "riscv64"]
+        {% if target_emulated_platform != "riscv64" %}
+          {% set emulated_c_stdlib_version = "2.28" %}
+        - gcc_impl_linux-{{ target_emulated_platform }}
         # We need to force 2.28 for the cross-test (otherwise we'd have to find which sysroot is installed)
-        - sysroot_linux-{{ target_emulated_platform }} =={{ emulated_c_stdlib_version }}  # [target_emulated_platform != "riscv64"]
+        - sysroot_linux-{{ target_emulated_platform }} =={{ emulated_c_stdlib_version }}
+        {% else %}
+          {% set emulated_c_stdlib_version = "2.39" %}
+        {% endif %}
+
       files:
         - tests/hello_from.c
         - tests/execve_call.c

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -133,9 +133,11 @@ outputs:
         - test -f ${PREFIX}/etc/conda/activate.d/qemu-execve-{{ target_emulated_platform }}-activate.sh
         - test -f ${PREFIX}/etc/conda/deactivate.d/qemu-execve-{{ target_emulated_platform }}-deactivate.sh
         - qemu-execve-{{ target_emulated_platform }} -h
+
         # waiting for https://github.com/conda-forge/ctng-compilers-feedstock/pull/205 to be merged
         {% if target_emulated_platform != "riscv64" %}
         # Test the normal execution of a cross-compiled binary
+        - export QEMU_CPU=power9  # [ppc64le]
         - {{ target_emulated_gcc }} -Wl,-rpath,${QEMU_LD_PREFIX}/lib -Wl,-rpath,${QEMU_LD_PREFIX}/lib64 -L$QEMU_LD_PREFIX/lib64:$QEMU_LD_PREFIX/lib -o hello_from tests/hello_from.c
         - qemu-execve-{{ target_emulated_platform }} ./hello_from {{ target_emulated_platform }} > hello.txt
         - grep "Hello, I'm executing {{ target_emulated_platform }} instructions!" hello.txt
@@ -148,6 +150,7 @@ outputs:
         - grep "Invalid ELF image" ls_{{ target_emulated_platform }}.txt || exit 1
         # Test redirected execve() execution of a cross-compiled binary - Redirected to qemu which executes the binary
         - QEMU_EXECVE=${PREFIX}/bin/qemu-execve-{{ target_emulated_platform }} qemu-execve-{{ target_emulated_platform }} ./execve_call "./hello_from" "EXECVE" > execve_call.txt 2>&1 || true
+        - cat execve_call.txt
         - grep "EXECVE" execve_call.txt || exit 1
         {% endif %}
       requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,12 +22,13 @@
   "fr-ch", "hr", "hu", "is", "it", "ja", "lt", "lv", "mk", "nl", "no", "pl", "pt", "pt-br", "ru", "th", "tr"
   ]
 %}
+
 # override c_stdlib_version for riscv because we cannot do it in CBC yet, see
 # https://github.com/conda/conda-build/issues/5884
 {% if target_emulated_platform == "riscv64" %}
-{% set emulated_c_stdlib_version = "2.39" %}
+  {% set emulated_c_stdlib_version = "2.39" %}
 {% else %}
-{% set emulated_c_stdlib_version = "2.28" %}
+  {% set emulated_c_stdlib_version = "2.28" %}
 {% endif %}
 
 package:
@@ -138,11 +139,11 @@ outputs:
         {% if target_emulated_platform != "riscv64" %}
         # Test the normal execution of a cross-compiled binary
         - export QEMU_CPU=power9  # [ppc64le]
-        - {{ target_emulated_gcc }} -Wl,-rpath,${QEMU_LD_PREFIX}/lib -Wl,-rpath,${QEMU_LD_PREFIX}/lib64 -L$QEMU_LD_PREFIX/lib64:$QEMU_LD_PREFIX/lib -o hello_from tests/hello_from.c
+        - {{ target_emulated_gcc }} -Wl,-rpath,${QEMU_LD_PREFIX}/lib -Wl,-rpath,${QEMU_LD_PREFIX}/lib64 -L$QEMU_LD_PREFIX/lib64:$QEMU_LD_PREFIX/lib -Wl,--dynamic-linker=$QEMU_LD_PREFIX/lib/ld-{{ emulated_c_stdlib_version }}.so -o hello_from tests/hello_from.c
         - qemu-execve-{{ target_emulated_platform }} ./hello_from {{ target_emulated_platform }} > hello.txt
         - grep "Hello, I'm executing {{ target_emulated_platform }} instructions!" hello.txt
         # Test the typical execve() execution of a non-cross-compiled binary (x86_64)
-        - {{ target_emulated_gcc }} -Wl,-rpath,${QEMU_LD_PREFIX}/lib -Wl,-rpath,${QEMU_LD_PREFIX}/lib64 -L$QEMU_LD_PREFIX/lib64:$QEMU_LD_PREFIX/lib -o execve_call tests/execve_call.c
+        - {{ target_emulated_gcc }} -Wl,-rpath,${QEMU_LD_PREFIX}/lib -Wl,-rpath,${QEMU_LD_PREFIX}/lib64 -L$QEMU_LD_PREFIX/lib64:$QEMU_LD_PREFIX/lib -Wl,--dynamic-linker=$QEMU_LD_PREFIX/lib/ld-{{ emulated_c_stdlib_version }}.so -o execve_call tests/execve_call.c
         - qemu-execve-{{ target_emulated_platform }} ./execve_call "/bin/ls" > ls_x86_64.txt 2>&1 || true
         - grep "hello_from" ls_x86_64.txt
         # Test redirected execve() execution of a non-cross-compiled binary (x86_64) - Must fail with 'Invalid ELF image'
@@ -150,7 +151,6 @@ outputs:
         - grep "Invalid ELF image" ls_{{ target_emulated_platform }}.txt || exit 1
         # Test redirected execve() execution of a cross-compiled binary - Redirected to qemu which executes the binary
         - QEMU_EXECVE=${PREFIX}/bin/qemu-execve-{{ target_emulated_platform }} qemu-execve-{{ target_emulated_platform }} ./execve_call "./hello_from" "EXECVE" > execve_call.txt 2>&1 || true
-        - cat execve_call.txt
         - grep "EXECVE" execve_call.txt || exit 1
         {% endif %}
       requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,6 @@
 {% set emulated_c_stdlib_version = "2.39" %}
 {% else %}
 {% set emulated_c_stdlib_version = "2.28" %}
-{% set c_stdlib_version = "2.28" %}
 {% endif %}
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -120,14 +120,17 @@ outputs:
       build:
         - {{ stdlib('c') }}
       host:
-        - {{ pin_subpackage('qemu-shared-resources', exact=True) }}
         - libcapstone
         - glib
+        - libslirp
         {% if target_emulated_platform == "aarch64" %}
         - zlib
         {% endif %}
       run:
-        - sysroot_linux-{{ target_emulated_platform }} >={{ emulated_c_stdlib_version }}
+        - libcapstone
+        - libglib
+        # Proposing to remove this run/req, users should know to provide the sysroot
+        # - sysroot_linux-{{ target_emulated_platform }} >={{ emulated_c_stdlib_version }}
     test:
       commands:
         - test -f ${PREFIX}/bin/qemu-execve-{{ target_emulated_platform }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -132,9 +132,6 @@ outputs:
         - test -f ${PREFIX}/bin/qemu-execve-{{ target_emulated_platform }}
         - test -f ${PREFIX}/etc/conda/activate.d/qemu-execve-{{ target_emulated_platform }}-activate.sh
         - test -f ${PREFIX}/etc/conda/deactivate.d/qemu-execve-{{ target_emulated_platform }}-deactivate.sh
-        - test -f ${QEMU_LD_PREFIX}/lib/ld-{{ c_stdlib_version }}.so  # [target_emulated_platform != "riscv64"]
-        # naming convention for ld-{{ c_stdlib_version }}.so varies by architecture on riscv and might be missing in some cases.
-        - test -f ${QEMU_LD_PREFIX}/lib/ld-linux-riscv64-lp64d.so.1   # [target_emulated_platform == "riscv64"]
         - qemu-execve-{{ target_emulated_platform }} -h
         # waiting for https://github.com/conda-forge/ctng-compilers-feedstock/pull/205 to be merged
         {% if target_emulated_platform != "riscv64" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -156,6 +156,8 @@ outputs:
       requires:
         # waiting for https://github.com/conda-forge/ctng-compilers-feedstock/pull/205 to be merged
         - gcc_impl_linux-{{ target_emulated_platform }}  # [target_emulated_platform != "riscv64"]
+        # We need to force 2.28 for the cross-test (otherwise we'd have to find which sysroot is installed)
+        - sysroot_linux-{{ target_emulated_platform }} =={{ emulated_c_stdlib_version }}  # [target_emulated_platform != "riscv64"]
       files:
         - tests/hello_from.c
         - tests/execve_call.c

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,44 +73,16 @@ requirements:
   host:
     - libcapstone
     - glib
-    - libseccomp
+    # - libseccomp
+    - libslirp
     - meson >=1.1.0
     - sphinx >=3.4.3
     - sphinx-rtd-theme >=0.5
+    {% if target_emulated_platform == "aarch64" %}
     - zlib
+    {% endif %}
 
 outputs:
-  - name: qemu-shared-resources
-    files:
-      - include/qemu-plugin.h
-      - share/qemu/trace-events-all
-
-      {% for bin in qemu_bins %}
-      - share/qemu/{{ bin }}
-      {% endfor %}
-
-      {% for keymap in qemu_keymaps %}
-      - share/qemu/keymaps/{{ keymap }}
-      {% endfor %}
-    requirements:
-      build:
-        - {{ compiler('c') }}
-        - {{ stdlib('c') }}
-      host:
-      run:
-    test:
-      commands:
-        - test -f ${PREFIX}/share/qemu/trace-events-all
-
-        {% for bin in qemu_bins %}
-        - test -f ${PREFIX}/share/qemu/{{ bin }}
-        {% endfor %}
-
-        {% for keymap in qemu_keymaps %}
-        - test -f ${PREFIX}/share/qemu/keymaps/{{ keymap }}
-        {% endfor %}
-
-
   - name: qemu-execve-{{ target_emulated_platform }}
     files:
       - bin/qemu-execve-{{ target_emulated_platform }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,11 +22,11 @@
   "fr-ch", "hr", "hu", "is", "it", "ja", "lt", "lv", "mk", "nl", "no", "pl", "pt", "pt-br", "ru", "th", "tr"
   ]
 %}
-# # override c_stdlib_version for riscv because we cannot do it in CBC yet, see
-# # https://github.com/conda/conda-build/issues/5884
-# {% if target_emulated_platform == "riscv64" %}
-# {% set c_stdlib_version = "2.39" %}
-# {% endif %}
+# override c_stdlib_version for riscv because we cannot do it in CBC yet, see
+# https://github.com/conda/conda-build/issues/5884
+{% if target_emulated_platform == "riscv64" %}
+{% set c_stdlib_version = "2.39" %}
+{% endif %}
 
 package:
   name: qemu-execve-split

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,11 +22,11 @@
   "fr-ch", "hr", "hu", "is", "it", "ja", "lt", "lv", "mk", "nl", "no", "pl", "pt", "pt-br", "ru", "th", "tr"
   ]
 %}
-# override emulated_c_stdlib_version for riscv because we cannot do it in CBC yet, see
-# https://github.com/conda/conda-build/issues/5884
-{% if target_emulated_platform == "riscv64" %}
-{% set emulated_c_stdlib_version = "2.39" %}
-{% endif %}
+# # override c_stdlib_version for riscv because we cannot do it in CBC yet, see
+# # https://github.com/conda/conda-build/issues/5884
+# {% if target_emulated_platform == "riscv64" %}
+# {% set c_stdlib_version = "2.39" %}
+# {% endif %}
 
 package:
   name: qemu-execve-split
@@ -46,7 +46,7 @@ source:
 
 build:
   skip: true  # [not (linux and x86_64)]
-  number: 0
+  number: 1
   script:
     - ${RECIPE_DIR}/helpers/build-install.sh
   script_env:
@@ -122,7 +122,7 @@ outputs:
         - zlib
         {% endif %}
       run:
-        - {{ emulated_c_stdlib }}_linux-{{ target_emulated_platform }} >={{ emulated_c_stdlib_version }}
+        - {{ c_stdlib }}_linux-{{ target_emulated_platform }} >={{ c_stdlib_version }}
     test:
       commands:
         - test -f ${PREFIX}/bin/qemu-execve-{{ target_emulated_platform }}
@@ -135,11 +135,11 @@ outputs:
         # waiting for https://github.com/conda-forge/ctng-compilers-feedstock/pull/205 to be merged
         {% if target_emulated_platform != "riscv64" %}
         # Test the normal execution of a cross-compiled binary
-        - {{ target_emulated_gcc }} -Wl,-rpath,${QEMU_LD_PREFIX}/lib -Wl,-rpath,${QEMU_LD_PREFIX}/lib64 -L$QEMU_LD_PREFIX/lib64:$QEMU_LD_PREFIX/lib -Wl,--dynamic-linker=$QEMU_LD_PREFIX/lib/ld-{{ emulated_c_stdlib_version }}.so -o hello_from tests/hello_from.c
+        - {{ target_emulated_gcc }} -Wl,-rpath,${QEMU_LD_PREFIX}/lib -Wl,-rpath,${QEMU_LD_PREFIX}/lib64 -L$QEMU_LD_PREFIX/lib64:$QEMU_LD_PREFIX/lib -Wl,--dynamic-linker=$QEMU_LD_PREFIX/lib/ld-{{ c_stdlib_version }}.so -o hello_from tests/hello_from.c
         - qemu-execve-{{ target_emulated_platform }} ./hello_from {{ target_emulated_platform }} > hello.txt
         - grep "Hello, I'm executing {{ target_emulated_platform }} instructions!" hello.txt
         # Test the typical execve() execution of a non-cross-compiled binary (x86_64)
-        - {{ target_emulated_gcc }} -Wl,-rpath,${QEMU_LD_PREFIX}/lib -Wl,-rpath,${QEMU_LD_PREFIX}/lib64 -L$QEMU_LD_PREFIX/lib64:$QEMU_LD_PREFIX/lib -Wl,--dynamic-linker=$QEMU_LD_PREFIX/lib/ld-{{ emulated_c_stdlib_version }}.so -o execve_call tests/execve_call.c
+        - {{ target_emulated_gcc }} -Wl,-rpath,${QEMU_LD_PREFIX}/lib -Wl,-rpath,${QEMU_LD_PREFIX}/lib64 -L$QEMU_LD_PREFIX/lib64:$QEMU_LD_PREFIX/lib -Wl,--dynamic-linker=$QEMU_LD_PREFIX/lib/ld-{{ c_stdlib_version }}.so -o execve_call tests/execve_call.c
         - qemu-execve-{{ target_emulated_platform }} ./execve_call "/bin/ls" > ls_x86_64.txt 2>&1 || true
         - grep "hello_from" ls_x86_64.txt
         # Test redirected execve() execution of a non-cross-compiled binary (x86_64) - Must fail with 'Invalid ELF image'
@@ -152,7 +152,7 @@ outputs:
       requires:
         # waiting for https://github.com/conda-forge/ctng-compilers-feedstock/pull/205 to be merged
         - gcc_impl_linux-{{ target_emulated_platform }}  # [target_emulated_platform != "riscv64"]
-        - sysroot_linux-{{ target_emulated_platform }} {{ emulated_c_stdlib_version }}.*  
+        - sysroot_linux-{{ target_emulated_platform }} {{ c_stdlib_version }}.*  
       files:
         - tests/hello_from.c
         - tests/execve_call.c

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,7 @@
 {% set emulated_c_stdlib_version = "2.39" %}
 {% else %}
 {% set emulated_c_stdlib_version = "2.28" %}
+{% set c_stdlib_version = "2.28" %}
 {% endif %}
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -128,8 +128,9 @@ outputs:
         - test -f ${PREFIX}/bin/qemu-execve-{{ target_emulated_platform }}
         - test -f ${PREFIX}/etc/conda/activate.d/qemu-execve-{{ target_emulated_platform }}-activate.sh
         - test -f ${PREFIX}/etc/conda/deactivate.d/qemu-execve-{{ target_emulated_platform }}-deactivate.sh
-        - test -f ${QEMU_LD_PREFIX}/lib/ld-{{ emulated_c_stdlib_version }}.so  # [target_emulated_platform != "riscv64"]
-        - test -f ${QEMU_LD_PREFIX}/lib/ld-linux-riscv64-lp64d.so.1  # [target_emulated_platform == "riscv64"]
+        - test -f ${QEMU_LD_PREFIX}/lib/ld-{{ c_stdlib_version }}.so  # [target_emulated_platform != "riscv64"]
+        # naming convention for ld-{{ c_stdlib_version }}.so varies by architecture on riscv and might be missing in some cases.
+        - test -f ${QEMU_LD_PREFIX}/lib/ld-linux-riscv64-lp64d.so.1   # [target_emulated_platform == "riscv64"]
         - qemu-execve-{{ target_emulated_platform }} -h
         # waiting for https://github.com/conda-forge/ctng-compilers-feedstock/pull/205 to be merged
         {% if target_emulated_platform != "riscv64" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,11 @@
   "fr-ch", "hr", "hu", "is", "it", "ja", "lt", "lv", "mk", "nl", "no", "pl", "pt", "pt-br", "ru", "th", "tr"
   ]
 %}
+# override emulated_c_stdlib_version for riscv because we cannot do it in CBC yet, see
+# https://github.com/conda/conda-build/issues/5884
+{% if target_emulated_platform == "riscv64" %}
+{% set emulated_c_stdlib_version = "2.39" %}
+{% endif %}
 
 package:
   name: qemu-execve-split
@@ -124,7 +129,9 @@ outputs:
         - test -f ${PREFIX}/etc/conda/activate.d/qemu-execve-{{ target_emulated_platform }}-activate.sh
         - test -f ${PREFIX}/etc/conda/deactivate.d/qemu-execve-{{ target_emulated_platform }}-deactivate.sh
         - test -f ${QEMU_LD_PREFIX}/lib/ld-{{ emulated_c_stdlib_version }}.so  # [target_emulated_platform != "riscv64"]
+        - test -f ${QEMU_LD_PREFIX}/lib/ld-linux-riscv64-lp64d.so.1  # [target_emulated_platform == "riscv64"]
         - qemu-execve-{{ target_emulated_platform }} -h
+        # waiting for https://github.com/conda-forge/ctng-compilers-feedstock/pull/205 to be merged
         {% if target_emulated_platform != "riscv64" %}
         # Test the normal execution of a cross-compiled binary
         - {{ target_emulated_gcc }} -Wl,-rpath,${QEMU_LD_PREFIX}/lib -Wl,-rpath,${QEMU_LD_PREFIX}/lib64 -L$QEMU_LD_PREFIX/lib64:$QEMU_LD_PREFIX/lib -Wl,--dynamic-linker=$QEMU_LD_PREFIX/lib/ld-{{ emulated_c_stdlib_version }}.so -o hello_from tests/hello_from.c
@@ -142,8 +149,9 @@ outputs:
         - grep "EXECVE" execve_call.txt || exit 1
         {% endif %}
       requires:
+        # waiting for https://github.com/conda-forge/ctng-compilers-feedstock/pull/205 to be merged
         - gcc_impl_linux-{{ target_emulated_platform }}  # [target_emulated_platform != "riscv64"]
-        - sysroot_linux-{{ target_emulated_platform }} {{ emulated_c_stdlib_version }}.*  # [target_emulated_platform != "riscv64"]
+        - sysroot_linux-{{ target_emulated_platform }} {{ emulated_c_stdlib_version }}.*  
       files:
         - tests/hello_from.c
         - tests/execve_call.c


### PR DESCRIPTION
In the context of https://github.com/conda-forge/conda-forge.github.io/issues/1744#issuecomment-3546242641, we need QEMU v10.2 for RISC-V to support subsequent images. Since the RISC-V toolchain https://github.com/conda-forge/ctng-compilers-feedstock/pull/205 is not yet ready, [the compilation part of the tests](https://github.com/conda-forge/qemu-execve-feedstock/pull/15/files#diff-f3725a55bf339595bf865fec73bda8ac99f283b0810c205442021f29c06eea9aR128-R143) has been disabled; this can be reverted once the toolchain is available. For now, we can perform a temporary build for use in `docker-images`.